### PR TITLE
EmulatorDxe: Support building with EMU_X64_RAZ_WI_PIO=YES

### DIFF
--- a/Docs/Building.md
+++ b/Docs/Building.md
@@ -183,6 +183,16 @@ can also try building with EMU_TIMEOUT_NONE for maximum performance.
 
 Note 1: EmulatorTest will _not_ correctly work with EMU_TIMEOUT_NONE.
 
+### Building With EMU_X64_RAZ_WI_PIO=YES
+
+If you run a DEBUG build of a UEFI implementation that uses the
+BaseIoLibIntrinsic (IoLibNoIo.c) implementation instead of a more
+advanced variant forwarding I/O accesses to PCIe, you may see UEFI
+assertions with emulated x64 drivers that attempt port I/O.
+
+Building with EMU_X64_RAZ_WI_PIO=YES will ignore all port I/O writes
+and return zeroes for all port I/O reads.
+
 ### Building Without Any Logging
 
 Finally, you can choose to build with BaseDebugLibNull. By default

--- a/Drivers/Emulator/Emulator.c
+++ b/Drivers/Emulator/Emulator.c
@@ -107,6 +107,7 @@ EmulatorDxeEntryPoint (
     return Status;
   }
 
+ #ifndef MAU_EMU_X64_RAZ_WI_PIO
   Status = gBS->LocateProtocol (
                   &gEfiCpuIo2ProtocolGuid,
                   NULL,
@@ -115,6 +116,8 @@ EmulatorDxeEntryPoint (
   if (Status != EFI_SUCCESS) {
     DEBUG ((DEBUG_WARN, "EFI_CPU_IO2_PROTOCOL is missing\n"));
   }
+
+ #endif /* MAU_EMU_X64_RAZ_WI_PIO */
 
   Status = CpuInit ();
   if (EFI_ERROR (Status)) {

--- a/Drivers/Emulator/Emulator.h
+++ b/Drivers/Emulator/Emulator.h
@@ -160,9 +160,9 @@ extern EFI_CPU_IO2_PROTOCOL       *gCpuIo2;
 extern EFI_LOADED_IMAGE_PROTOCOL  *gDriverImage;
 
 VOID
-  EmulatorDump (
-                VOID
-                );
+EmulatorDump (
+  VOID
+  );
 
 ImageRecord *
 ImageFindByAddress (

--- a/Emulator.dsc
+++ b/Emulator.dsc
@@ -49,6 +49,14 @@
   #
   SUPPORTS_AARCH64_BINS          = NO
   #
+  # Say YES if you want to ignore all port I/O writes (reads
+  # returning zero), instead of forwarding to EFI_CPU_IO2_PROTOCOL.
+  #
+  # Useful for testing on UEFI DEBUG builds that use the
+  # BaseIoLibIntrinsic (IoLibNoIo.c) implementation.
+  #
+  EMU_X64_RAZ_WI_PIO             = NO
+  #
   # Seems to work well even when building on small machines.
   #
   UC_LTO_JOBS                    = auto
@@ -145,6 +153,9 @@
 !if $(SUPPORTS_AARCH64_BINS) == YES
   *_*_*_CC_FLAGS                       = -DMAU_SUPPORTS_AARCH64_BINS
 !endif
+!endif
+!if $(EMU_X64_RAZ_WI_PIO) == YES
+  *_*_*_CC_FLAGS                       = -DMAU_EMU_X64_RAZ_WI_PIO
 !endif
 
 [Components]


### PR DESCRIPTION
If you run a DEBUG build of a UEFI implementation that uses the BaseIoLibIntrinsic (IoLibNoIo.c) implementation instead of a more advanced variant forwarding I/O accesses to PCIe, you may see UEFI assertions with emulated x64 drivers that attempt port I/O.

Building with EMU_X64_RAZ_WI_PIO=YES will ignore all port I/O writes and return zeroes for all port I/O reads.