### PR TITLE
Fix race between JIT executing emulated code and another image starting.

### DIFF
--- a/Docs/EmulatedEnvironment.md
+++ b/Docs/EmulatedEnvironment.md
@@ -103,7 +103,7 @@ Note: empty comment field below indicates full support.
 ## Supported Runtime Services (RT)
 
 Boot Service drivers and UEFI applications may make use of RT services
-as well. The EFI_RUNTIMET_SERVICES table is passed verbatim, and reports
+as well. The EFI_RUNTIME_SERVICES table is passed verbatim, and reports
 the host UEFI Specification revision and host-specific function pointer
 addresses, even for functionality that is filtered/adjusted/disabled.
 
@@ -135,9 +135,9 @@ Note: empty comment field below indicates full support.
 | Service | Comments |
 | :-: | ------------ |
 | FlushDataCache |
-| EnableInterrupt | Returns EFI_UNSUPPORTED |
-| DisableInterrupt | Returns EFI_UNSUPPORTED |
-| GetInterruptState | Returns EFI_UNSUPPORTED |
+| EnableInterrupt | |
+| DisableInterrupt | |
+| GetInterruptState | |
 | Init | Returns EFI_UNSUPPORTED |
 | GetTimerValue | |
 | SetMemoryAttributes | See [notes on memory attributes](#-notes-on-memory-attributes) |

--- a/Drivers/Emulator/EfiHooks.c
+++ b/Drivers/Emulator/EfiHooks.c
@@ -1,0 +1,138 @@
+/** @file
+
+    Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+**/
+
+#include "Emulator.h"
+
+/*
+ * EfiHooks modify the UEFI environment presented to all UEFI code,
+ * including ourselves. This is done by modifying the function
+ * indirection tables (e.g. protocols).
+ *
+ * This is different from EfiWrappers, which only modify the
+ * emulated UEFI environment, by redirecting or denying attempts to
+ * execute certain native functions.
+ */
+
+UINTN                               gIgnoreInterruptManipulation;
+BOOLEAN                             gApparentInterruptState;
+STATIC EFI_CPU_ENABLE_INTERRUPT     mRealEnableInterrupt;
+STATIC EFI_CPU_DISABLE_INTERRUPT    mRealDisableInterrupt;
+STATIC EFI_CPU_GET_INTERRUPT_STATE  mRealGetInterruptState;
+
+EFI_STATUS
+EFIAPI
+EfiHooksCpuEnableInterrupt (
+  IN EFI_CPU_ARCH_PROTOCOL  *This
+  )
+{
+  gApparentInterruptState = TRUE;
+
+  if (gIgnoreInterruptManipulation == 0) {
+    return mRealEnableInterrupt (This);
+  }
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+EfiHooksCpuDisableInterrupt (
+  IN EFI_CPU_ARCH_PROTOCOL  *This
+  )
+{
+  gApparentInterruptState = FALSE;
+
+  if (gIgnoreInterruptManipulation == 0) {
+    return mRealDisableInterrupt (This);
+  }
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+EfiHooksCpuGetInterruptState (
+  IN  EFI_CPU_ARCH_PROTOCOL  *This,
+  OUT BOOLEAN                *State
+  )
+{
+  if (State == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (gIgnoreInterruptManipulation == 0) {
+    return mRealGetInterruptState (This, State);
+  }
+
+  *State = gApparentInterruptState;
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EfiHooksInit (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  /*
+   * The JIT engine is not reentrant, so it has to run
+   * uninterrupted. This is done by disabling the interrupts.
+   * Of course, we can't have the emulated code enable interrupts,
+   * but it gets dicier than that, since the interrupt state is
+   * also manipulated implicitly by manipulating the TPL (both
+   * by emulated and native code). Thus we disconnect the notion
+   * of real interrupt state (now owned by us) from the apparent
+   * interrupt state (as seen by everything else).
+   */
+  Status = gCpu->GetInterruptState (gCpu, &gApparentInterruptState);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: GetInterruptState: %r\n",
+      __FUNCTION__,
+      Status
+      ));
+    return Status;
+  }
+
+  CriticalBegin ();
+  mRealEnableInterrupt   = gCpu->EnableInterrupt;
+  mRealDisableInterrupt  = gCpu->DisableInterrupt;
+  mRealGetInterruptState = gCpu->GetInterruptState;
+
+  /*
+   * Tiano doesn't do anything crazy like protecting protocols
+   * to be RO. A UEFI implementation might, in which case maybe
+   * SetMemoryAttributes will help. Or maybe your SOL. Have fun!
+   *
+   * N.B. even if you can't hook this way, you could always
+   * set a breakpoint exception. Ugh, though.
+   */
+  gCpu->EnableInterrupt   = EfiHooksCpuEnableInterrupt;
+  gCpu->DisableInterrupt  = EfiHooksCpuDisableInterrupt;
+  gCpu->GetInterruptState = EfiHooksCpuGetInterruptState;
+  CriticalEnd ();
+
+  return EFI_SUCCESS;
+}
+
+VOID
+EfiHooksCleanup (
+  VOID
+  )
+{
+  CriticalBegin ();
+  gCpu->EnableInterrupt   = mRealEnableInterrupt;
+  gCpu->DisableInterrupt  = mRealDisableInterrupt;
+  gCpu->GetInterruptState = mRealGetInterruptState;
+  CriticalEnd ();
+}

--- a/Drivers/Emulator/Emulator.c
+++ b/Drivers/Emulator/Emulator.c
@@ -96,6 +96,11 @@ EmulatorStart (
   EFI_HANDLE  EmuHandleAArch64 = NULL;
  #endif /* MAU_SUPPORTS_AARCH64_BINS */
 
+  Status = EfiHooksInit ();
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
   EfiWrappersInit ();
 
   Status = CpuInit ();
@@ -106,6 +111,7 @@ EmulatorStart (
   Status = ArchInit ();
   if (EFI_ERROR (Status)) {
     CpuCleanup ();
+    EfiHooksCleanup ();
     return Status;
   }
 
@@ -170,6 +176,7 @@ done:
  #endif /* MAU_SUPPORTS_AARCH64_BINS */
     ArchCleanup ();
     CpuCleanup ();
+    EfiHooksCleanup ();
   }
 
   return Status;

--- a/Drivers/Emulator/Emulator.inf
+++ b/Drivers/Emulator/Emulator.inf
@@ -26,6 +26,7 @@
   ComponentName.c
   Cpu.c
   DriverBinding.c
+  EfiHooks.c
   EfiWrappers.c
   Emulator.c
   Entry.c


### PR DESCRIPTION
More silent corruption due to lack of reentrance. But it's not enough to wrap uc_mem_protect...interrupts can be re-enabled inside JITted code (or really anytime) due to TPL manipulation, so need to hook the EFI_CPU_ARCH_PROTOCOL interrupt manipulation routines.

Very much reaching the point where a better JIT needs to be written that doesn't have the reentrancy issues.