### PR TITLE
Emulator.dsc: Change BaseStackCheckLib to StackCheckLibNull

### DIFF
--- a/Emulator.dsc
+++ b/Emulator.dsc
@@ -155,9 +155,9 @@
   DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
   #
   # Since software stack checking may be heuristically enabled by the compiler
-  # include BaseStackCheckLib unconditionally.
+  # include StackCheckLib unconditionally.
   #
-  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
+  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
   #
   # Misc.
   #


### PR DESCRIPTION
Since EDKII PR: https://github.com/tianocore/edk2/pull/5957 has been removed the BaseStackCheckLib, and the new StackCheckLib dependency library StackCheckFailureHookLib has not yet been made public, so we can only use StackCheckLibNull.